### PR TITLE
Fix: destroys the foreign key in the invoice items upon deletion

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
 	belongs_to :merchant
-	has_many :invoice_items
+	has_many :invoice_items, dependent: :destroy
 	has_many :invoices
 	has_many :invoices, through: :invoice_items
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
   get "/api/v1/merchants/:id/items", to: "api/v1/merchant_items#index"
   get "/api/v1/merchants/:id/invoices", to: "api/v1/merchant_invoices#index"
   
-
-  # non-RESTful endpoints
   get "/api/v1/items/find_all", to: "api/v1/items#find_all"
 
   get "/api/v1/items", to: "api/v1/items#index"

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1,7 +1,7 @@
 {
   "RSpec": {
     "coverage": {
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/environment.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/environment.rb": {
         "lines": [
           null,
           1,
@@ -10,7 +10,7 @@
           1
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/application.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/application.rb": {
         "lines": [
           1,
           null,
@@ -58,7 +58,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/boot.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/boot.rb": {
         "lines": [
           1,
           null,
@@ -66,7 +66,7 @@
           1
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/environments/test.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/environments/test.rb": {
         "lines": [
           1,
           null,
@@ -134,7 +134,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/initializers/cors.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/initializers/cors.rb": {
         "lines": [
           null,
           null,
@@ -154,7 +154,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/initializers/filter_parameter_logging.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/initializers/filter_parameter_logging.rb": {
         "lines": [
           null,
           null,
@@ -166,7 +166,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/initializers/inflections.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/initializers/inflections.rb": {
         "lines": [
           null,
           null,
@@ -186,7 +186,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/config/routes.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/config/routes.rb": {
         "lines": [
           1,
           1,
@@ -214,7 +214,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/customer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/customer.rb": {
         "lines": [
           1,
           1,
@@ -224,14 +224,14 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/application_record.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/application_record.rb": {
         "lines": [
           1,
           1,
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/models/invoice_item_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/models/invoice_item_spec.rb": {
         "lines": [
           1,
           null,
@@ -245,41 +245,6 @@
           2,
           2,
           2,
-          2,
-          2,
-          2,
-          2,
-          2,
-          null,
-          null
-        ]
-      },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/invoice_item.rb": {
-        "lines": [
-          1,
-          1,
-          1,
-          null,
-          1,
-          1,
-          null,
-          null
-        ]
-      },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/models/invoice_spec.rb": {
-        "lines": [
-          1,
-          null,
-          1,
-          1,
-          2,
-          2,
-          2,
-          2,
-          2,
-          null,
-          null,
-          1,
           2,
           2,
           2,
@@ -289,7 +254,42 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/invoice.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/invoice_item.rb": {
+        "lines": [
+          1,
+          1,
+          1,
+          null,
+          1,
+          1,
+          null,
+          null
+        ]
+      },
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/models/invoice_spec.rb": {
+        "lines": [
+          1,
+          null,
+          1,
+          1,
+          2,
+          2,
+          2,
+          2,
+          2,
+          null,
+          null,
+          1,
+          2,
+          2,
+          2,
+          2,
+          2,
+          null,
+          null
+        ]
+      },
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/invoice.rb": {
         "lines": [
           1,
           1,
@@ -308,7 +308,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/models/item_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/models/item_spec.rb": {
         "lines": [
           1,
           null,
@@ -363,7 +363,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/item.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/item.rb": {
         "lines": [
           1,
           1,
@@ -416,7 +416,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/models/merchant_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/models/merchant_spec.rb": {
         "lines": [
           1,
           null,
@@ -525,7 +525,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/merchant.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/merchant.rb": {
         "lines": [
           1,
           1,
@@ -567,7 +567,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/models/transaction_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/models/transaction_spec.rb": {
         "lines": [
           1,
           null,
@@ -578,14 +578,14 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/models/transaction.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/models/transaction.rb": {
         "lines": [
           1,
           1,
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/requests/api/v1/items_request_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/requests/api/v1/items_request_spec.rb": {
         "lines": [
           1,
           null,
@@ -861,7 +861,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/spec/requests/api/v1/merchants_request_spec.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/spec/requests/api/v1/merchants_request_spec.rb": {
         "lines": [
           1,
           null,
@@ -1203,7 +1203,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/items_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/items_controller.rb": {
         "lines": [
           1,
           1,
@@ -1254,13 +1254,13 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/application_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/application_controller.rb": {
         "lines": [
           1,
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/serializers/item_serializer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/serializers/item_serializer.rb": {
         "lines": [
           1,
           1,
@@ -1269,7 +1269,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/items_merchant_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/items_merchant_controller.rb": {
         "lines": [
           1,
           null,
@@ -1285,7 +1285,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/serializers/merchant_serializer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/serializers/merchant_serializer.rb": {
         "lines": [
           1,
           1,
@@ -1300,7 +1300,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/serializers/error_serializer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/serializers/error_serializer.rb": {
         "lines": [
           1,
           1,
@@ -1330,7 +1330,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/merchants_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/merchants_controller.rb": {
         "lines": [
           1,
           1,
@@ -1386,7 +1386,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/merchant_customers_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/merchant_customers_controller.rb": {
         "lines": [
           1,
           null,
@@ -1398,7 +1398,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/serializers/customer_serializer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/serializers/customer_serializer.rb": {
         "lines": [
           1,
           1,
@@ -1406,7 +1406,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/merchant_items_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/merchant_items_controller.rb": {
         "lines": [
           1,
           1,
@@ -1426,7 +1426,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/controllers/api/v1/merchant_invoices_controller.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/controllers/api/v1/merchant_invoices_controller.rb": {
         "lines": [
           1,
           null,
@@ -1447,7 +1447,7 @@
           null
         ]
       },
-      "/Users/krrrl/turing/2mod/projects/silk_road/little_silk_road/app/serializers/invoice_serializer.rb": {
+      "/Users/renee/turing/2mod/projects/little_silk_road/app/serializers/invoice_serializer.rb": {
         "lines": [
           1,
           1,
@@ -1456,6 +1456,6 @@
         ]
       }
     },
-    "timestamp": 1726528219
+    "timestamp": 1726596296
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -13,7 +13,7 @@
       <img src="./assets/0.13.1/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2024-09-16T17:10:19-06:00">2024-09-16T17:10:19-06:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2024-09-17T14:04:56-04:00">2024-09-17T14:04:56-04:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -70,7 +70,7 @@
       <tbody>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2c6bb209a62691935e04fc4bb7818dbb438074ab" class="src_link" title="app/controllers/api/v1/items_controller.rb">app/controllers/api/v1/items_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#baca46a498133a136ada05698070d1ee213f6e85" class="src_link" title="app/controllers/api/v1/items_controller.rb">app/controllers/api/v1/items_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">47</td>
             <td class="cell--number">27</td>
@@ -81,7 +81,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#94ce6cb4e12c9d599f23360bc1f46e2c38aacdc3" class="src_link" title="app/controllers/api/v1/items_merchant_controller.rb">app/controllers/api/v1/items_merchant_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#f87621cd46044930a47cb8e6b76a6bfb4245a14d" class="src_link" title="app/controllers/api/v1/items_merchant_controller.rb">app/controllers/api/v1/items_merchant_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">12</td>
             <td class="cell--number">7</td>
@@ -92,7 +92,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e83767b556a5cd7487301289bbc052fbb1972eb9" class="src_link" title="app/controllers/api/v1/merchant_customers_controller.rb">app/controllers/api/v1/merchant_customers_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#39c6027a61fe38c85931dafdbfa10cf8e362fb24" class="src_link" title="app/controllers/api/v1/merchant_customers_controller.rb">app/controllers/api/v1/merchant_customers_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">5</td>
@@ -103,7 +103,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#8a835fb9e4953aabed4d316225333cd5153fecfa" class="src_link" title="app/controllers/api/v1/merchant_invoices_controller.rb">app/controllers/api/v1/merchant_invoices_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#9eb5b1a3972f521d08b9abe8d137082d00bc108a" class="src_link" title="app/controllers/api/v1/merchant_invoices_controller.rb">app/controllers/api/v1/merchant_invoices_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">17</td>
             <td class="cell--number">10</td>
@@ -114,7 +114,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d11e13073ff447124abf58fd4234169963c9b305" class="src_link" title="app/controllers/api/v1/merchant_items_controller.rb">app/controllers/api/v1/merchant_items_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#0d37be7695586e99580394598fbd7e26a829621e" class="src_link" title="app/controllers/api/v1/merchant_items_controller.rb">app/controllers/api/v1/merchant_items_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">16</td>
             <td class="cell--number">9</td>
@@ -125,7 +125,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#199feb214b92de6d7e503aebb1228f42ccc158c0" class="src_link" title="app/controllers/api/v1/merchants_controller.rb">app/controllers/api/v1/merchants_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#07e5ee808a9643bde6a8a11d1b75e375f999af3b" class="src_link" title="app/controllers/api/v1/merchants_controller.rb">app/controllers/api/v1/merchants_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">52</td>
             <td class="cell--number">29</td>
@@ -136,7 +136,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#d2c58d94d60cab40bcd41875553b411e93dd35a7" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
+            <td class="strong t-file__name"><a href="#ac8263c2b124962d2a71895b18865a61b2b658b2" class="src_link" title="app/controllers/application_controller.rb">app/controllers/application_controller.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">2</td>
             <td class="cell--number">1</td>
@@ -147,7 +147,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#6166e7c92e7de5c25a5af8b3d4be80823847dcea" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
+            <td class="strong t-file__name"><a href="#0f0a21c589d7e920128f291c9c6cf7d007279f4c" class="src_link" title="app/models/application_record.rb">app/models/application_record.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">3</td>
             <td class="cell--number">2</td>
@@ -158,7 +158,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#c0b92455308a327edad1d6b548a0895c9cd63d61" class="src_link" title="app/models/customer.rb">app/models/customer.rb</a></td>
+            <td class="strong t-file__name"><a href="#fbda727480b8141e3a6dca29d4f30e035f1a0d73" class="src_link" title="app/models/customer.rb">app/models/customer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">6</td>
             <td class="cell--number">4</td>
@@ -169,7 +169,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#47541ee849dc133e9ce50f6511566e8de3b749d5" class="src_link" title="app/models/invoice.rb">app/models/invoice.rb</a></td>
+            <td class="strong t-file__name"><a href="#03d29caf6c8b0c559d36d1d466bb3cff8474df1e" class="src_link" title="app/models/invoice.rb">app/models/invoice.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">15</td>
             <td class="cell--number">11</td>
@@ -180,7 +180,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#fc3c53d21f36ed69b36cea0f29c523df50fefa64" class="src_link" title="app/models/invoice_item.rb">app/models/invoice_item.rb</a></td>
+            <td class="strong t-file__name"><a href="#6737729c7ee91517781e02ecae7ca034b3cbf700" class="src_link" title="app/models/invoice_item.rb">app/models/invoice_item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">5</td>
@@ -191,7 +191,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1c321c1ef589f93740b80551e694311073ee81f7" class="src_link" title="app/models/item.rb">app/models/item.rb</a></td>
+            <td class="strong t-file__name"><a href="#d4424bb9b7570016eefa934cd56cc7dae2bb5b2a" class="src_link" title="app/models/item.rb">app/models/item.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">49</td>
             <td class="cell--number">28</td>
@@ -202,7 +202,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#29fc58760d02097fc1cd835c31399dfb0aaf42d3" class="src_link" title="app/models/merchant.rb">app/models/merchant.rb</a></td>
+            <td class="strong t-file__name"><a href="#b35cb0ce8cfd437f3ead7a551923910946dc003f" class="src_link" title="app/models/merchant.rb">app/models/merchant.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">38</td>
             <td class="cell--number">21</td>
@@ -213,7 +213,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#46a68450b7049dce11a9a86294e479400f4013e2" class="src_link" title="app/models/transaction.rb">app/models/transaction.rb</a></td>
+            <td class="strong t-file__name"><a href="#b2d4ce8d4f514482ad45f516c7eda1575f788448" class="src_link" title="app/models/transaction.rb">app/models/transaction.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">3</td>
             <td class="cell--number">2</td>
@@ -224,7 +224,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#044111ddd486b00dc5282bb957dbb4f8cf50711d" class="src_link" title="app/serializers/customer_serializer.rb">app/serializers/customer_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#2de436ab0b1b988aa5381f02fcacf528d85fddea" class="src_link" title="app/serializers/customer_serializer.rb">app/serializers/customer_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -235,7 +235,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#9e7f920f757f9e0bb4700baabb4688cd87c1d5f8" class="src_link" title="app/serializers/error_serializer.rb">app/serializers/error_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#82ace50164e607661b13c437fff86bbc98204d73" class="src_link" title="app/serializers/error_serializer.rb">app/serializers/error_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">26</td>
             <td class="cell--number">3</td>
@@ -246,7 +246,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#7119e96cc57e743632d5c85defd00660759fc300" class="src_link" title="app/serializers/invoice_serializer.rb">app/serializers/invoice_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#216e7d50ce647a0612a4720052138797fe7bbc22" class="src_link" title="app/serializers/invoice_serializer.rb">app/serializers/invoice_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -257,7 +257,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#273d8b9f7e64824cc74941fde3281bcf87c578cc" class="src_link" title="app/serializers/item_serializer.rb">app/serializers/item_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#1c7e382c546d611903de5d99fec9c490f007c484" class="src_link" title="app/serializers/item_serializer.rb">app/serializers/item_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">3</td>
@@ -268,7 +268,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2e329f58159fd8690ee47dbe57c3f2dd93e61c35" class="src_link" title="app/serializers/merchant_serializer.rb">app/serializers/merchant_serializer.rb</a></td>
+            <td class="strong t-file__name"><a href="#2f41b388dccf507af67814aebbb66c2f551dcf85" class="src_link" title="app/serializers/merchant_serializer.rb">app/serializers/merchant_serializer.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">11</td>
             <td class="cell--number">5</td>
@@ -279,7 +279,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#f1a950eea825143f209b3f6ac6017bc0505c0526" class="src_link" title="config/application.rb">config/application.rb</a></td>
+            <td class="strong t-file__name"><a href="#061cd6febca1f35e8f778ccb45751e53d9211a50" class="src_link" title="config/application.rb">config/application.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">44</td>
             <td class="cell--number">18</td>
@@ -290,7 +290,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#69270e2f09b750b782889390e5c9ee946c881025" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
+            <td class="strong t-file__name"><a href="#5229122b9edb169b56ae42a34f0968a937b0e8d2" class="src_link" title="config/boot.rb">config/boot.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">4</td>
             <td class="cell--number">3</td>
@@ -301,7 +301,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#f6033be9e3370872c4a592f23e142f25bdacbad6" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
+            <td class="strong t-file__name"><a href="#8000860ee05df351cedbe6882dc629da7db50442" class="src_link" title="config/environment.rb">config/environment.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">5</td>
             <td class="cell--number">2</td>
@@ -312,7 +312,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#5e7e831fe089858a799aa16581998eb84b3ae342" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
+            <td class="strong t-file__name"><a href="#ab77ed037e436750e5c4b320d00eb151645aa1b1" class="src_link" title="config/environments/test.rb">config/environments/test.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">64</td>
             <td class="cell--number">18</td>
@@ -323,7 +323,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2db1e561a4005cea6f73b8d1b21ce825759ef878" class="src_link" title="config/initializers/cors.rb">config/initializers/cors.rb</a></td>
+            <td class="strong t-file__name"><a href="#5ecc6d0ac273f49ee37b9935e1b1dbeaf5b1b075" class="src_link" title="config/initializers/cors.rb">config/initializers/cors.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">16</td>
             <td class="cell--number">4</td>
@@ -334,7 +334,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#6c3062d4bfb56703df4d0b6720860aad823ff3e4" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
+            <td class="strong t-file__name"><a href="#6e440347f1302a493185fc4971705db073b8d801" class="src_link" title="config/initializers/filter_parameter_logging.rb">config/initializers/filter_parameter_logging.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">8</td>
             <td class="cell--number">1</td>
@@ -345,7 +345,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#e6618b1e4abba523460d5cd655f6477d5b2caf0b" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
+            <td class="strong t-file__name"><a href="#c7c6020b07264b5d66cf6dec69922cc68c1747d0" class="src_link" title="config/initializers/inflections.rb">config/initializers/inflections.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">16</td>
             <td class="cell--number">0</td>
@@ -356,7 +356,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#8cfd8779857cfb0795eba9b51ec2a63338cd9d7f" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
+            <td class="strong t-file__name"><a href="#a97292bc19b8716d463aa6b896d5296a5b0e6cbf" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">24</td>
             <td class="cell--number">17</td>
@@ -367,7 +367,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#24265473ea4f6861d8be5597a3730943c751ea0c" class="src_link" title="spec/models/invoice_item_spec.rb">spec/models/invoice_item_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#d74f39953ba82af24c65a2ed2e048858f22e22c4" class="src_link" title="spec/models/invoice_item_spec.rb">spec/models/invoice_item_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">19</td>
             <td class="cell--number">14</td>
@@ -378,7 +378,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#def1b0e77e0f842a442c0d0541c92818ae0faf74" class="src_link" title="spec/models/invoice_spec.rb">spec/models/invoice_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#7923a3121db4d30677efba770bb23f854cda10ab" class="src_link" title="spec/models/invoice_spec.rb">spec/models/invoice_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">19</td>
             <td class="cell--number">14</td>
@@ -389,7 +389,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#114ac041d1fbb7a81073c273a1bee727af59365c" class="src_link" title="spec/models/item_spec.rb">spec/models/item_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#1cd739ffe163fe10a1171f35f43947eee2b019cd" class="src_link" title="spec/models/item_spec.rb">spec/models/item_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">51</td>
             <td class="cell--number">34</td>
@@ -400,7 +400,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#b7d6c1444c88b2025b719047983c8a06ead3fef6" class="src_link" title="spec/models/merchant_spec.rb">spec/models/merchant_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#ea6b467ee2a63bcab6da973104201e5374699579" class="src_link" title="spec/models/merchant_spec.rb">spec/models/merchant_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">105</td>
             <td class="cell--number">52</td>
@@ -411,7 +411,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#2b5b6f0fd616f3db09d59d56158722c0bc17068b" class="src_link" title="spec/models/transaction_spec.rb">spec/models/transaction_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#84c69f3fcc454eb74c08e34c90fa8ab3b08e86cd" class="src_link" title="spec/models/transaction_spec.rb">spec/models/transaction_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">7</td>
             <td class="cell--number">4</td>
@@ -422,7 +422,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#0039d09bd9bfc4e9e35d7b3480e874e9f92a33bd" class="src_link" title="spec/requests/api/v1/items_request_spec.rb">spec/requests/api/v1/items_request_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#431d315c200c66b302283ba3ede278996fc66b20" class="src_link" title="spec/requests/api/v1/items_request_spec.rb">spec/requests/api/v1/items_request_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">272</td>
             <td class="cell--number">135</td>
@@ -433,7 +433,7 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#275172c5105dc8e46301b5fd4c23f1b7f411ff16" class="src_link" title="spec/requests/api/v1/merchants_request_spec.rb">spec/requests/api/v1/merchants_request_spec.rb</a></td>
+            <td class="strong t-file__name"><a href="#90a8c47f7f75ed78ae501f00c1ed524b2150e476" class="src_link" title="spec/requests/api/v1/merchants_request_spec.rb">spec/requests/api/v1/merchants_request_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">338</td>
             <td class="cell--number">220</td>
@@ -460,7 +460,7 @@
 
       <div class="source_files">
       
-        <div class="source_table" id="2c6bb209a62691935e04fc4bb7818dbb438074ab">
+        <div class="source_table" id="baca46a498133a136ada05698070d1ee213f6e85">
   <div class="header">
     <h3>app/controllers/api/v1/items_controller.rb</h3>
     <h4>
@@ -1015,7 +1015,7 @@
 </div>
 
       
-        <div class="source_table" id="94ce6cb4e12c9d599f23360bc1f46e2c38aacdc3">
+        <div class="source_table" id="f87621cd46044930a47cb8e6b76a6bfb4245a14d">
   <div class="header">
     <h3>app/controllers/api/v1/items_merchant_controller.rb</h3>
     <h4>
@@ -1180,7 +1180,7 @@
 </div>
 
       
-        <div class="source_table" id="e83767b556a5cd7487301289bbc052fbb1972eb9">
+        <div class="source_table" id="39c6027a61fe38c85931dafdbfa10cf8e362fb24">
   <div class="header">
     <h3>app/controllers/api/v1/merchant_customers_controller.rb</h3>
     <h4>
@@ -1301,7 +1301,7 @@
 </div>
 
       
-        <div class="source_table" id="8a835fb9e4953aabed4d316225333cd5153fecfa">
+        <div class="source_table" id="9eb5b1a3972f521d08b9abe8d137082d00bc108a">
   <div class="header">
     <h3>app/controllers/api/v1/merchant_invoices_controller.rb</h3>
     <h4>
@@ -1522,7 +1522,7 @@
 </div>
 
       
-        <div class="source_table" id="d11e13073ff447124abf58fd4234169963c9b305">
+        <div class="source_table" id="0d37be7695586e99580394598fbd7e26a829621e">
   <div class="header">
     <h3>app/controllers/api/v1/merchant_items_controller.rb</h3>
     <h4>
@@ -1731,7 +1731,7 @@
 </div>
 
       
-        <div class="source_table" id="199feb214b92de6d7e503aebb1228f42ccc158c0">
+        <div class="source_table" id="07e5ee808a9643bde6a8a11d1b75e375f999af3b">
   <div class="header">
     <h3>app/controllers/api/v1/merchants_controller.rb</h3>
     <h4>
@@ -2340,7 +2340,7 @@
 </div>
 
       
-        <div class="source_table" id="d2c58d94d60cab40bcd41875553b411e93dd35a7">
+        <div class="source_table" id="ac8263c2b124962d2a71895b18865a61b2b658b2">
   <div class="header">
     <h3>app/controllers/application_controller.rb</h3>
     <h4>
@@ -2393,7 +2393,7 @@
 </div>
 
       
-        <div class="source_table" id="6166e7c92e7de5c25a5af8b3d4be80823847dcea">
+        <div class="source_table" id="0f0a21c589d7e920128f291c9c6cf7d007279f4c">
   <div class="header">
     <h3>app/models/application_record.rb</h3>
     <h4>
@@ -2458,7 +2458,7 @@
 </div>
 
       
-        <div class="source_table" id="c0b92455308a327edad1d6b548a0895c9cd63d61">
+        <div class="source_table" id="fbda727480b8141e3a6dca29d4f30e035f1a0d73">
   <div class="header">
     <h3>app/models/customer.rb</h3>
     <h4>
@@ -2557,7 +2557,7 @@
 </div>
 
       
-        <div class="source_table" id="47541ee849dc133e9ce50f6511566e8de3b749d5">
+        <div class="source_table" id="03d29caf6c8b0c559d36d1d466bb3cff8474df1e">
   <div class="header">
     <h3>app/models/invoice.rb</h3>
     <h4>
@@ -2760,7 +2760,7 @@
 </div>
 
       
-        <div class="source_table" id="fc3c53d21f36ed69b36cea0f29c523df50fefa64">
+        <div class="source_table" id="6737729c7ee91517781e02ecae7ca034b3cbf700">
   <div class="header">
     <h3>app/models/invoice_item.rb</h3>
     <h4>
@@ -2881,7 +2881,7 @@
 </div>
 
       
-        <div class="source_table" id="1c321c1ef589f93740b80551e694311073ee81f7">
+        <div class="source_table" id="d4424bb9b7570016eefa934cd56cc7dae2bb5b2a">
   <div class="header">
     <h3>app/models/item.rb</h3>
     <h4>
@@ -3458,7 +3458,7 @@
 </div>
 
       
-        <div class="source_table" id="29fc58760d02097fc1cd835c31399dfb0aaf42d3">
+        <div class="source_table" id="b35cb0ce8cfd437f3ead7a551923910946dc003f">
   <div class="header">
     <h3>app/models/merchant.rb</h3>
     <h4>
@@ -3911,7 +3911,7 @@
 </div>
 
       
-        <div class="source_table" id="46a68450b7049dce11a9a86294e479400f4013e2">
+        <div class="source_table" id="b2d4ce8d4f514482ad45f516c7eda1575f788448">
   <div class="header">
     <h3>app/models/transaction.rb</h3>
     <h4>
@@ -3976,7 +3976,7 @@
 </div>
 
       
-        <div class="source_table" id="044111ddd486b00dc5282bb957dbb4f8cf50711d">
+        <div class="source_table" id="2de436ab0b1b988aa5381f02fcacf528d85fddea">
   <div class="header">
     <h3>app/serializers/customer_serializer.rb</h3>
     <h4>
@@ -4053,7 +4053,7 @@
 </div>
 
       
-        <div class="source_table" id="9e7f920f757f9e0bb4700baabb4688cd87c1d5f8">
+        <div class="source_table" id="82ace50164e607661b13c437fff86bbc98204d73">
   <div class="header">
     <h3>app/serializers/error_serializer.rb</h3>
     <h4>
@@ -4350,7 +4350,7 @@
 </div>
 
       
-        <div class="source_table" id="7119e96cc57e743632d5c85defd00660759fc300">
+        <div class="source_table" id="216e7d50ce647a0612a4720052138797fe7bbc22">
   <div class="header">
     <h3>app/serializers/invoice_serializer.rb</h3>
     <h4>
@@ -4408,7 +4408,7 @@
 
             
 
-            <code class="ruby">  attributes  :status</code>
+            <code class="ruby">  attributes  :status, :merchant_id, :customer_id</code>
           </li>
         </div>
       
@@ -4427,7 +4427,7 @@
 </div>
 
       
-        <div class="source_table" id="273d8b9f7e64824cc74941fde3281bcf87c578cc">
+        <div class="source_table" id="1c7e382c546d611903de5d99fec9c490f007c484">
   <div class="header">
     <h3>app/serializers/item_serializer.rb</h3>
     <h4>
@@ -4514,7 +4514,7 @@
 </div>
 
       
-        <div class="source_table" id="2e329f58159fd8690ee47dbe57c3f2dd93e61c35">
+        <div class="source_table" id="2f41b388dccf507af67814aebbb66c2f551dcf85">
   <div class="header">
     <h3>app/serializers/merchant_serializer.rb</h3>
     <h4>
@@ -4665,7 +4665,7 @@
 </div>
 
       
-        <div class="source_table" id="f1a950eea825143f209b3f6ac6017bc0505c0526">
+        <div class="source_table" id="061cd6febca1f35e8f778ccb45751e53d9211a50">
   <div class="header">
     <h3>config/application.rb</h3>
     <h4>
@@ -5172,7 +5172,7 @@
 </div>
 
       
-        <div class="source_table" id="69270e2f09b750b782889390e5c9ee946c881025">
+        <div class="source_table" id="5229122b9edb169b56ae42a34f0968a937b0e8d2">
   <div class="header">
     <h3>config/boot.rb</h3>
     <h4>
@@ -5249,7 +5249,7 @@
 </div>
 
       
-        <div class="source_table" id="f6033be9e3370872c4a592f23e142f25bdacbad6">
+        <div class="source_table" id="8000860ee05df351cedbe6882dc629da7db50442">
   <div class="header">
     <h3>config/environment.rb</h3>
     <h4>
@@ -5334,7 +5334,7 @@
 </div>
 
       
-        <div class="source_table" id="5e7e831fe089858a799aa16581998eb84b3ae342">
+        <div class="source_table" id="ab77ed037e436750e5c4b320d00eb151645aa1b1">
   <div class="header">
     <h3>config/environments/test.rb</h3>
     <h4>
@@ -6041,7 +6041,7 @@
 </div>
 
       
-        <div class="source_table" id="2db1e561a4005cea6f73b8d1b21ce825759ef878">
+        <div class="source_table" id="5ecc6d0ac273f49ee37b9935e1b1dbeaf5b1b075">
   <div class="header">
     <h3>config/initializers/cors.rb</h3>
     <h4>
@@ -6240,7 +6240,7 @@
 </div>
 
       
-        <div class="source_table" id="6c3062d4bfb56703df4d0b6720860aad823ff3e4">
+        <div class="source_table" id="6e440347f1302a493185fc4971705db073b8d801">
   <div class="header">
     <h3>config/initializers/filter_parameter_logging.rb</h3>
     <h4>
@@ -6353,7 +6353,7 @@
 </div>
 
       
-        <div class="source_table" id="e6618b1e4abba523460d5cd655f6477d5b2caf0b">
+        <div class="source_table" id="c7c6020b07264b5d66cf6dec69922cc68c1747d0">
   <div class="header">
     <h3>config/initializers/inflections.rb</h3>
     <h4>
@@ -6544,7 +6544,7 @@
 </div>
 
       
-        <div class="source_table" id="8cfd8779857cfb0795eba9b51ec2a63338cd9d7f">
+        <div class="source_table" id="a97292bc19b8716d463aa6b896d5296a5b0e6cbf">
   <div class="header">
     <h3>config/routes.rb</h3>
     <h4>
@@ -6646,7 +6646,7 @@
 
             
 
-            <code class="ruby">  get &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#show&quot;</code>
+            <code class="ruby">  get &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#show&quot;#, constraints: { id: /\d+/ }</code>
           </li>
         </div>
       
@@ -6670,7 +6670,7 @@
 
             
 
-            <code class="ruby">  patch &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#update&quot;</code>
+            <code class="ruby">  patch &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#update&quot;#, constraints: { id: /\d+/ }</code>
           </li>
         </div>
       
@@ -6682,7 +6682,7 @@
 
             
 
-            <code class="ruby">  delete &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#destroy&quot;</code>
+            <code class="ruby">  delete &quot;/api/v1/merchants/:id&quot;, to: &quot;api/v1/merchants#destroy&quot;#, constraints: { id: /\d+/ }</code>
           </li>
         </div>
       
@@ -6849,7 +6849,7 @@
 </div>
 
       
-        <div class="source_table" id="24265473ea4f6861d8be5597a3730943c751ea0c">
+        <div class="source_table" id="d74f39953ba82af24c65a2ed2e048858f22e22c4">
   <div class="header">
     <h3>spec/models/invoice_item_spec.rb</h3>
     <h4>
@@ -7098,7 +7098,7 @@
 </div>
 
       
-        <div class="source_table" id="def1b0e77e0f842a442c0d0541c92818ae0faf74">
+        <div class="source_table" id="7923a3121db4d30677efba770bb23f854cda10ab">
   <div class="header">
     <h3>spec/models/invoice_spec.rb</h3>
     <h4>
@@ -7347,7 +7347,7 @@
 </div>
 
       
-        <div class="source_table" id="114ac041d1fbb7a81073c273a1bee727af59365c">
+        <div class="source_table" id="1cd739ffe163fe10a1171f35f43947eee2b019cd">
   <div class="header">
     <h3>spec/models/item_spec.rb</h3>
     <h4>
@@ -7956,7 +7956,7 @@
 </div>
 
       
-        <div class="source_table" id="b7d6c1444c88b2025b719047983c8a06ead3fef6">
+        <div class="source_table" id="ea6b467ee2a63bcab6da973104201e5374699579">
   <div class="header">
     <h3>spec/models/merchant_spec.rb</h3>
     <h4>
@@ -9141,7 +9141,7 @@
 </div>
 
       
-        <div class="source_table" id="2b5b6f0fd616f3db09d59d56158722c0bc17068b">
+        <div class="source_table" id="84c69f3fcc454eb74c08e34c90fa8ab3b08e86cd">
   <div class="header">
     <h3>spec/models/transaction_spec.rb</h3>
     <h4>
@@ -9250,7 +9250,7 @@
 </div>
 
       
-        <div class="source_table" id="0039d09bd9bfc4e9e35d7b3480e874e9f92a33bd">
+        <div class="source_table" id="431d315c200c66b302283ba3ede278996fc66b20">
   <div class="header">
     <h3>spec/requests/api/v1/items_request_spec.rb</h3>
     <h4>
@@ -12271,7 +12271,7 @@
 </div>
 
       
-        <div class="source_table" id="275172c5105dc8e46301b5fd4c23f1b7f411ff16">
+        <div class="source_table" id="90a8c47f7f75ed78ae501f00c1ed524b2150e476">
   <div class="header">
     <h3>spec/requests/api/v1/merchants_request_spec.rb</h3>
     <h4>


### PR DESCRIPTION
Updated the Items controller to include the destroy dependents for the invoice items.