### PR TITLE
Merchants index coupon count invoice coupon count

### DIFF
--- a/app/controllers/api/v1/merchant_invoices_controller.rb
+++ b/app/controllers/api/v1/merchant_invoices_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::MerchantInvoicesController < ApplicationController
   def create
     merchant = Merchant.find(params[:merchant_id])
     invoice = Invoice.create_an_invoice(merchant, invoice_params)
+    invoice.is_a?(Invoice) ? render(json: InvoiceSerializer.new(invoice), status: :created) : render(json: { errors: invoice[:errors] }, status: :bad_request)  
   end
 
 private

--- a/app/controllers/api/v1/merchant_invoices_controller.rb
+++ b/app/controllers/api/v1/merchant_invoices_controller.rb
@@ -14,7 +14,17 @@ class Api::V1::MerchantInvoicesController < ApplicationController
     invoice = merchant.invoices.find(params[:id])
     render json: InvoiceSerializer.new(invoice)
   end
+
+  def create
+    merchant = Merchant.find(params[:merchant_id])
+    invoice = Invoice.create_an_invoice(merchant, invoice_params)
+  end
+
 private
+
+  def invoice_params
+    params.require(:invoice).permit(:customer_id, :merchant_id, :coupon_id, :status)
+  end
 
   def not_found_response(exception)
     render json: ErrorSerializer.format_error(exception, "404"), status: :not_found

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -15,7 +15,8 @@ class Coupon < ApplicationRecord
   validate :max_coupons_per_merchant
 
   def self.create_a_coupon(merchant, coupon_params)
-    return {errors: "Merchant can only have 5 active coupons"} if merchant.coupons.count >= 5
+    return {errors: "Merchant can only have 5 active coupons"} if merchant.coupons.active.count >= 5
+    return {errors: "Coupon code must be unique"} if merchant.coupons.exists?(code: coupon_params[:code])
     merchant.coupons.create(coupon_params)
   end
 
@@ -34,9 +35,9 @@ class Coupon < ApplicationRecord
 
   def self.sort_by_status(sorted)
     if sorted == "active"
-      where(status: "activated")
+      where(status: "activated").order(status: :asc)
     elsif sorted == "inactive"
-      where(status: "deactivated")
+      where(status: "deactivated").order(status: :asc)
     else
       all
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -13,4 +13,8 @@ class Invoice < ApplicationRecord
     return all unless status.present?
     where(status: status)
 	end
+
+	def self.create_an_invoice(merchant, invoice_params)
+		merchant.invoices.create(invoice_params)
+	end
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,6 +1,13 @@
 class MerchantSerializer
   include JSONAPI::Serializer
   attributes :name
+
+  attribute :coupons_count do |merchant|
+    merchant.coupons.count
+  end
+  attribute :invoice_coupon_count do |merchant|
+    merchant.invoices.where.not(coupon_id: nil).count
+  end
   attribute :item_count, if: Proc.new { |merchant, params| params[:count] == "true" } do |merchant|
     merchant.item_count
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,13 @@ Rails.application.routes.draw do
   get "/api/v1/items/:id/merchant", to: "api/v1/items_merchant#index"
 
   # Routing for Coupon Project (in order of CRUD Endpoints of BE requirements)
-  get "/api/v1/merchants/:merchant_id/coupons/:id", to: "api/v1/coupons#show"
-  get "/api/v1/merchants/:merchant_id/coupons", to: "api/v1/coupons#index"
-  post "/api/v1/merchants/:merchant_id/coupons", to: "api/v1/coupons#create"
-  patch "/api/v1/merchants/:merchant_id/coupons/:id", to: "api/v1/coupons#update"
-  get "/api/v1/merchants/:merchant_id/invoices/:id", to: "api/v1/merchant_invoices#show"
+  get "/api/v1/merchants/:merchant_id/coupons/:id", to: "api/v1/coupons#show" #Merchant Coupon Show
+  get "/api/v1/merchants/:merchant_id/coupons", to: "api/v1/coupons#index" #Merchant Coupons Index
+  post "/api/v1/merchants/:merchant_id/coupons", to: "api/v1/coupons#create" #Merchant Coupon Create
+  patch "/api/v1/merchants/:merchant_id/coupons/:id", to: "api/v1/coupons#update" #Merchant Coupon Activate/Deactivate
+  # http://localhost:3000/api/v1/merchants/112/coupons?sorted=inactive
+  post "/api/v1/merchants/:merchant_id/invoices", to: "api/v1/merchant_invoices#create" #Merchant Invoice (create an invoice)
+  get "/api/v1/merchants/:merchant_id/invoices/:id", to: "api/v1/merchant_invoices#show" #Merchant Invoice
 
 end
   

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Invoice, type: :model do
     @invoice2 = Invoice.create!(customer_id: @real_human2.id, merchant_id: @macho_man.id, status: 'returned')   
     @invoice3 = Invoice.create!(customer_id: @real_human2.id, merchant_id: @macho_man.id, status: 'returned')
     @invoice4 = Invoice.create!(customer_id: @real_human2.id, merchant_id: @macho_man.id, status: 'packaged')
+
+    @coupon1 = Coupon.create!(name: "Test 1", code: "Unique1", percent_off: 20, status: "activated", merchant: @macho_man)
   end
 
   describe "filtering invoices by status" do
@@ -54,6 +56,19 @@ RSpec.describe Invoice, type: :model do
       expect(packaged_invoices).to include(@invoice4)
       expect(packaged_invoices).to_not include(@invoice1, @invoice2, @invoice3)
       expect(packaged_invoices.count).to eq(1)
+    end
+    # Final Project Method Test
+    it 'can create a new invoice' do
+      new_invoice_params = {customer_id: @real_human1.id, merchant_id: @macho_man.id, coupon_id: @coupon1.id, status: "shipped"}
+
+      Invoice.create_an_invoice(@macho_man, new_invoice_params)
+
+      result = Invoice.last
+
+      expect(result.customer_id).to eq(@real_human1.id)
+      expect(result.merchant_id).to eq(@macho_man.id)
+      expect(result.coupon_id).to eq(@coupon1.id)
+      expect(result.status).to eq("shipped")
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -164,7 +164,9 @@ RSpec.describe 'Item Endpoints:' do
             id: @kozey_group.id.to_s,
             type: "merchant",
             attributes: {
-                name: @kozey_group.name
+                name: @kozey_group.name,
+                coupons_count: @kozey_group.coupons.count,
+                invoice_coupon_count: @kozey_group.invoices.where.not(coupon_id: nil).count
             }
         }
     }

--- a/spec/requests/api/v1/merchant_invoices_request_spec.rb
+++ b/spec/requests/api/v1/merchant_invoices_request_spec.rb
@@ -42,5 +42,21 @@ RSpec.describe 'Merchant Invoices' do
         expect(invoice_w_coupon[:attributes][:status]).to eq("shipped")
       end
     end
+
+    describe "Create" do
+      it 'can create an invoice for a merchant' do
+        invoice_params = {
+          customer_id: @real_human1.id,
+          merchant_id: @macho_man.id,
+          coupon_id: @coupon1.id,
+          status: "shipped"
+        }
+
+        post "/api/v1/merchants/#{@macho_man.id}/invoices", params: {invoice: invoice_params}
+
+        expect(response).to be_successful
+
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/merchant_invoices_request_spec.rb
+++ b/spec/requests/api/v1/merchant_invoices_request_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe 'Merchant Invoices' do
 
         expect(response).to be_successful
 
+        new_invoice = JSON.parse(response.body, symbolize_names: true)[:data]
+
+        expect(new_invoice[:attributes][:customer_id]).to eq(@real_human1.id)
+        expect(new_invoice[:attributes][:merchant_id]).to eq(@macho_man.id)
+        expect(new_invoice[:attributes][:coupon_id]).to eq(@coupon1.id)
+        expect(new_invoice[:attributes][:status]).to eq("shipped")
       end
     end
   end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -38,15 +38,28 @@ RSpec.describe 'Merchant Endpoints:' do
 
         expect(merchant).to have_key(:name)
         expect(merchant[:name]).to be_a(String)
+
+        expect(merchant).to have_key(:coupons_count)
+        expect(merchant[:coupons_count]).to be_a(Integer)
+
+        expect(merchant).to have_key(:invoice_coupon_count)
+        expect(merchant[:invoice_coupon_count]).to be_a(Integer)
       end
     end
 
     it "Can return one merchant" do
       get "/api/v1/merchants/#{@macho_man.id}"
       expect(response).to be_successful
+
       merchant = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expected_coupons_count = @macho_man.coupons.count
+      expected_invoice_coupon_count = @macho_man.invoices.where.not(coupon_id: nil).count
+
       expect(merchant[:id]).to eq(@macho_man.id.to_s)
       expect(merchant[:attributes][:name]).to eq(@macho_man.name)
+      expect(merchant[:attributes][:coupons_count]).to eq(expected_coupons_count)
+      expect(merchant[:attributes][:invoice_coupon_count]).to eq(expected_invoice_coupon_count)
     end
 
     it "Can create a merchant" do
@@ -60,6 +73,11 @@ RSpec.describe 'Merchant Endpoints:' do
   
       new_merchant = Merchant.last
       expect(new_merchant.name).to eq(merchant_params[:name])
+
+      merchant_coupons = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+      expect(merchant_coupons[:coupons_count]).to eq(0)
+      expect(merchant_coupons[:invoice_coupon_count]).to eq(0)
     end
 
     it "Can update a merchant's name" do

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -92,6 +92,11 @@ RSpec.describe 'Merchant Endpoints:' do
       expect(response).to be_successful
       expect(updated_merchant.name).to_not eq(previous_name)
       expect(updated_merchant.name).to eq("Kozey Grove co.")
+
+      merchant_coupons = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+      expect(merchant_coupons[:coupons_count]).to eq(0)
+      expect(merchant_coupons[:invoice_coupon_count]).to eq(0)
     end
 
     it 'Can delete a merchant and all of their items' do
@@ -243,6 +248,11 @@ RSpec.describe 'Merchant Endpoints:' do
       expect(response.status).to eq(200)
       expect(data[:id]).to eq(store2.id.to_s)
       expect(data[:attributes][:name]).to eq(store2.name)
+
+      merchant_coupons = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+      expect(merchant_coupons[:coupons_count]).to eq(0)
+      expect(merchant_coupons[:invoice_coupon_count]).to eq(0)
     end
 
     it 'can handle incorrect searches' do
@@ -267,7 +277,12 @@ RSpec.describe 'Merchant Endpoints:' do
       merchants = JSON.parse(response.body, symbolize_names: true)[:data]
       
       expect(merchants.first[:attributes][:name]).to eq(@hot_topic.name)
+      expect(merchants.first[:attributes][:coupons_count]).to eq(0)
+      expect(merchants.first[:attributes][:invoice_coupon_count]).to eq(0)
+      
       expect(merchants.last[:attributes][:name]).to eq(@macho_man.name)
+      expect(merchants.last[:attributes][:coupons_count]).to eq(0)
+      expect(merchants.last[:attributes][:invoice_coupon_count]).to eq(0)
     end
 
     it 'can display only merchants with invoice status="returned"' do
@@ -280,6 +295,8 @@ RSpec.describe 'Merchant Endpoints:' do
       
       expect(merchants.first[:attributes][:name]).not_to eq([@kozey_group.name])
       expect(merchants.first[:attributes][:name]).to eq(@macho_man.name)
+      expect(merchants.first[:attributes][:coupons_count]).to eq(0)
+      expect(merchants.first[:attributes][:invoice_coupon_count]).to eq(0)
     end
 
     it 'can display count of how many items a merchant has' do


### PR DESCRIPTION
### Merchants - Update the merchants index endpoint to include a count of coupons for each merchant and a count of invoices with coupons applied for each merchant.

Updated many models, including coupon.rb and invoice.rb
merchant_invoices_controller got new #create and a private invoice_params method for formatting
testing of invoices_spec.rb and merchants_requests_spec.
2 new routes and actions

Postman endpoints working as BE requirements demand.